### PR TITLE
Add the grackle cooling mode to configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2963,6 +2963,18 @@ case "$with_rt_riemann_solver" in
         ;;
 esac
 
+# For GEAR-RT scheme: Select a grackle cooling mode for thermochemistry
+AC_ARG_WITH([gearrt-grackle-mode],
+   [AS_HELP_STRING([--with-gearrt-grackle-mode=<mode_number>],
+      [Grackle cooling mode is to control with primordial chemistry network is used @<:@0, 1, 2, 3, default: 1@:>@.
+      For the GEAR RT scheme, you need to select one grackle cooling mode.]
+   )],
+   [with_gearrt_grackle_mode="$withval"],
+   [with_gearrt_grackle_mode="1"]
+)
+
+AC_DEFINE_UNQUOTED([COOLING_GRACKLE_MODE], [$with_gearrt_grackle_mode], [Primordial chemistry network to use])
+
 case "$with_rt" in
    none)
       AC_DEFINE([RT_NONE], [1], [No radiative transfer scheme])
@@ -2976,10 +2988,21 @@ case "$with_rt" in
       if test "$number_group" = "0"; then
           AC_MSG_ERROR([GEAR-RT: Cannot work with zero photon groups])
       fi
+
       if ! test $number_group -eq $number_group; then
           # abuse -eq to check whether $number_group is an integer. -eq
           # only works with those.
           AC_MSG_ERROR([GEAR-RT: Cannot work with non-integer photon groups])
+      fi
+
+      if test "$with_gearrt_grackle_mode" -gr 3; then
+          AC_MSG_ERROR([GEAR-RT: Cannot work with grackle mode greater than 3])
+      fi
+
+      if ! test $with_gearrt_grackle_mode -eq $with_gearrt_grackle_mode; then
+          # abuse -eq to check whether $with_gearrt_grackle_mode is an integer. -eq
+          # only works with those.
+          AC_MSG_ERROR([GEAR-RT: Cannot work with non-integer grackle mode])
       fi
 
       if test "$enable_debugging_checks" = "yes"; then

--- a/configure.ac
+++ b/configure.ac
@@ -2966,11 +2966,11 @@ esac
 # For GEAR-RT scheme: Select a grackle cooling mode for thermochemistry
 AC_ARG_WITH([gearrt-grackle-mode],
    [AS_HELP_STRING([--with-gearrt-grackle-mode=<mode_number>],
-      [Grackle cooling mode is to control with primordial chemistry network is used @<:@0, 1, 2, 3, default: 1@:>@.
+      [Grackle cooling mode is to control with primordial chemistry network is used @<:@0, 1, 2, 3, default: none@:>@.
       For the GEAR RT scheme, you need to select one grackle cooling mode.]
    )],
    [with_gearrt_grackle_mode="$withval"],
-   [with_gearrt_grackle_mode="1"]
+   [with_gearrt_grackle_mode="none"]
 )
 
 AC_DEFINE_UNQUOTED([GEARRT_GRACKLE_MODE], [$with_gearrt_grackle_mode], [Primordial chemistry network to use])
@@ -2995,7 +2995,12 @@ case "$with_rt" in
           AC_MSG_ERROR([GEAR-RT: Cannot work with non-integer photon groups])
       fi
 
-      if test "$with_gearrt_grackle_mode" -gr 3; then
+      if test "$with_gearrt_grackle_mode" = "none"; then
+	  # only allow the numeric [0-3] for different chemistry network.
+          AC_MSG_ERROR([GEAR-RT: You need to select an RT grackle cooling mode (--with-gearrt-grackle-mode=...)])
+      fi
+
+      if test "$with_gearrt_grackle_mode" -gt 3; then
           AC_MSG_ERROR([GEAR-RT: Cannot work with grackle mode greater than 3])
       fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -669,6 +669,9 @@ if test "$enable_opt" = "yes" ; then
       if test "$ax_cv_c_compiler_vendor" = "intel"; then
       	 CFLAGS="$CFLAGS -no-vec -no-simd"
       	 AC_MSG_RESULT([disabled Intel vectorization])
+      elif test "$ax_cv_c_compiler_vendor" = "oneapi"; then
+         CFLAGS="$CFLAGS -no-vec"
+         AC_MSG_RESULT([disabled oneAPI vectorization])
       elif test "$ax_cv_c_compiler_vendor" = "gnu"; then
       	 CFLAGS="$CFLAGS -fno-tree-vectorize"
       	 AC_MSG_RESULT([disabled GCC vectorization])
@@ -1228,7 +1231,7 @@ if test "x$with_tcmalloc" != "xno"; then
 
       # Prevent compilers that replace the calls with built-ins (GNU 99) from doing so.
       case "$ax_cv_c_compiler_vendor" in
-        intel | gnu | clang)
+        intel | gnu | clang | oneapi)
              CFLAGS="$CFLAGS -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free"
           ;;
       esac
@@ -1271,7 +1274,7 @@ if test "x$with_jemalloc" != "xno"; then
 
       # Prevent compilers that replace the regular calls with built-ins (GNU 99) from doing so.
       case "$ax_cv_c_compiler_vendor" in
-        intel | gnu | clang)
+        intel | gnu | clang | oneapi)
              CFLAGS="$CFLAGS -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free"
           ;;
       esac
@@ -1314,7 +1317,7 @@ if test "x$with_tbbmalloc" != "xno"; then
 
       # Prevent compilers that replace the calls with built-ins (GNU 99) from doing so.
       case "$ax_cv_c_compiler_vendor" in
-        intel | gnu | clang)
+        intel | gnu | clang | oneapi)
              CFLAGS="$CFLAGS -fno-builtin-malloc -fno-builtin-calloc -fno-builtin-realloc -fno-builtin-free"
           ;;
       esac
@@ -1820,12 +1823,13 @@ if test "$enable_warn" != "no"; then
     # AX_CFLAGS_WARN_ALL does not give good warning flags for the Intel compiler
     # We will do this by hand instead and only default to the macro for unknown compilers
     case "$ax_cv_c_compiler_vendor" in
-          gnu | clang)
+          gnu | clang | oneapi)
              CFLAGS="$CFLAGS -Wall -Wextra -Wno-unused-parameter -Wshadow"
           ;;
 	  intel)
              CFLAGS="$CFLAGS -w2 -Wunused-variable -Wshadow"
           ;;
+
 	  *)
 	     AX_CFLAGS_WARN_ALL
 	  ;;
@@ -1834,7 +1838,7 @@ if test "$enable_warn" != "no"; then
     # Add a "choke on warning" flag if it exists
     if test "$enable_warn" = "error"; then
        case "$ax_cv_c_compiler_vendor" in
-          intel | gnu | clang)
+          intel | gnu | clang | oneapi)
              CFLAGS="$CFLAGS -Werror"
           ;;
        esac

--- a/configure.ac
+++ b/configure.ac
@@ -2973,7 +2973,7 @@ AC_ARG_WITH([gearrt-grackle-mode],
    [with_gearrt_grackle_mode="1"]
 )
 
-AC_DEFINE_UNQUOTED([COOLING_GRACKLE_MODE], [$with_gearrt_grackle_mode], [Primordial chemistry network to use])
+AC_DEFINE_UNQUOTED([GEARRT_GRACKLE_MODE], [$with_gearrt_grackle_mode], [Primordial chemistry network to use])
 
 case "$with_rt" in
    none)

--- a/src/partition.c
+++ b/src/partition.c
@@ -2063,7 +2063,7 @@ void partition_init(struct partition *partition,
 
 #ifdef WITH_MPI
 
-/* Defaults make use of METIS if available */
+  /* Defaults make use of METIS if available */
 #if defined(HAVE_METIS) || defined(HAVE_PARMETIS)
   const char *default_repart = "fullcosts";
   const char *default_part = "edgememory";
@@ -2078,6 +2078,10 @@ void partition_init(struct partition *partition,
          &partition->grid[2]);
   factor(partition->grid[0] * partition->grid[1], &partition->grid[1],
          &partition->grid[0]);
+
+  /* Initialise the repartition celllist. */
+  repartition->ncelllist = 0;
+  repartition->celllist = NULL;
 
   /* Now let's check what the user wants as an initial domain. */
   char part_type[20];
@@ -2187,10 +2191,6 @@ void partition_init(struct partition *partition,
   repartition->itr =
       parser_get_opt_param_float(params, "DomainDecomposition:itr", 100.0f);
 
-  /* Clear the celllist for use. */
-  repartition->ncelllist = 0;
-  repartition->celllist = NULL;
-
   /* Do we have fixed costs available? These can be used to force
    * repartitioning at any time. Not required if not repartitioning.*/
   repartition->use_fixed_costs = parser_get_opt_param_int(
@@ -2216,6 +2216,24 @@ void partition_init(struct partition *partition,
 
 #else
   error("SWIFT was not compiled with MPI support");
+#endif
+}
+
+/**
+ * @brief Clean up any allocated resources.
+ *
+ * @param partition The #partition
+ * @param repartition The #repartition
+ */
+void partition_clean(struct partition *partition,
+                     struct repartition *repartition) {
+#ifdef WITH_MPI
+  /* Only the celllist is dynamic. */
+  if (repartition->celllist != NULL) free(repartition->celllist);
+
+  /* Zero structs for reuse. */
+  bzero(partition, sizeof(struct partition));
+  bzero(repartition, sizeof(struct repartition));
 #endif
 }
 

--- a/src/partition.h
+++ b/src/partition.h
@@ -83,6 +83,9 @@ void partition_init(struct partition *partition,
                     struct repartition *repartition,
                     struct swift_params *params, int nr_nodes);
 
+void partition_clean(struct partition *partition,
+                     struct repartition *repartition);
+
 /* Dump/restore. */
 void partition_store_celllist(struct space *s, struct repartition *reparttype);
 void partition_restore_celllist(struct space *s,

--- a/swift.c
+++ b/swift.c
@@ -1935,6 +1935,7 @@ int main(int argc, char *argv[]) {
   free(output_options);
 
 #ifdef WITH_MPI
+  partition_clean(&initial_partition, &reparttype);
   if ((res = MPI_Finalize()) != MPI_SUCCESS)
     error("call to MPI_Finalize failed with error %i.", res);
 #endif

--- a/swift_fof.c
+++ b/swift_fof.c
@@ -777,6 +777,7 @@ int main(int argc, char *argv[]) {
   free(output_options);
 
 #ifdef WITH_MPI
+  partition_clean(&initial_partition, &reparttype);
   if ((res = MPI_Finalize()) != MPI_SUCCESS)
     error("call to MPI_Finalize failed with error %i.", res);
 #endif


### PR DESCRIPTION
I add a new flag while compiling the GEAR-RT, and it is called -with-gearrt-grackle-mode. 

And it will give a macro called COOLING_GRACKLE_MODE in config.h which can give a numeric for this macro and it is useful for later defining different mode in GEAR-RT code.