### PR TITLE
Rt grackle add3species for grackle mode 2

### DIFF
--- a/src/rt/GEAR/rt_struct.h
+++ b/src/rt/GEAR/rt_struct.h
@@ -64,6 +64,7 @@ struct rt_part_data {
   /* } limiter[RT_NGROUPS]; */
 
   /* Data for thermochemistry */
+#if GEARRT_GRACKLE_MODE == 1
   struct {
     float mass_fraction_HI;         /* mass fraction taken by HI */
     float mass_fraction_HII;        /* mass fraction taken by HII */
@@ -72,6 +73,19 @@ struct rt_part_data {
     float mass_fraction_HeIII;      /* mass fraction taken by HeIII */
     float number_density_electrons; /* number density of electrons */
   } tchem;
+#elif GEARRT_GRACKLE_MODE == 2
+  struct {
+    float mass_fraction_HI;         /* mass fraction taken by HI */
+    float mass_fraction_HII;        /* mass fraction taken by HII */
+    float mass_fraction_HeI;        /* mass fraction taken by HeI */
+    float mass_fraction_HeII;       /* mass fraction taken by HeII */
+    float mass_fraction_HeIII;      /* mass fraction taken by HeIII */
+    float number_density_electrons; /* number density of electrons */
+    float mass_fraction_HM;         /* mass fraction taken by HM */
+    float mass_fraction_H2I;         /* mass fraction taken by H2I */
+    float mass_fraction_H2II;         /* mass fraction taken by H2II */
+  } tchem;
+#endif
 
 #ifdef GIZMO_MFV_SPH
   /* Keep track of the actual mass fluxes of the gas species */

--- a/src/rt/GEAR/rt_thermochemistry_utils.h
+++ b/src/rt/GEAR/rt_thermochemistry_utils.h
@@ -111,22 +111,35 @@ __attribute__((always_inline)) INLINE static float rt_tchem_internal_energy_dT(
  **/
 __attribute__((always_inline)) INLINE static void
 rt_tchem_get_species_densities(const struct part* restrict p, gr_float rho,
-                               gr_float species_densities[6]) {
+                               gr_float species_densities[RT_N_SPECIES]) {
+  /* for primordial_chemistry >= 1 */
+  #if GEARRT_GRACKLE_MODE >= 1
+    species_densities[0] = p->rt_data.tchem.mass_fraction_HI * rho;
+    species_densities[1] = p->rt_data.tchem.mass_fraction_HII * rho;
+    species_densities[2] = p->rt_data.tchem.mass_fraction_HeI * rho;
+    species_densities[3] = p->rt_data.tchem.mass_fraction_HeII * rho;
+    species_densities[4] = p->rt_data.tchem.mass_fraction_HeIII * rho;
 
-  species_densities[0] = p->rt_data.tchem.mass_fraction_HI * rho;
-  species_densities[1] = p->rt_data.tchem.mass_fraction_HII * rho;
-  species_densities[2] = p->rt_data.tchem.mass_fraction_HeI * rho;
-  species_densities[3] = p->rt_data.tchem.mass_fraction_HeII * rho;
-  species_densities[4] = p->rt_data.tchem.mass_fraction_HeIII * rho;
-
-  /* nHII = rho_HII / m_p
-   * nHeII = rho_HeII / 4 m_p
-   * nHeIII = rho_HeIII / 4 m_p
-   * ne = nHII + nHeII + 2 * nHeIII
-   * But: it is grackle convention to use rho_e = n_e * m_p */
-  const gr_float rho_e = species_densities[1] + 0.25 * species_densities[3] +
+    /* nHII = rho_HII / m_p
+     * nHeII = rho_HeII / 4 m_p
+     * nHeIII = rho_HeIII / 4 m_p
+     * ne = nHII + nHeII + 2 * nHeIII
+     * But: it is grackle convention to use rho_e = n_e * m_p */
+    const gr_float rho_e = species_densities[1] + 0.25 * species_densities[3] +
                          0.5 * species_densities[4];
-  species_densities[5] = rho_e;
+    species_densities[5] = rho_e;
+  #endif
+
+  /* for primordial_chemistry >= 2 */
+  #if GEARRT_GRACKLE_MODE >= 2
+    species_densities[6] = p->rt_data.tchem.mass_fraction_HM * rho;
+    species_densities[7] = p->rt_data.tchem.mass_fraction_H2I * rho;
+    species_densities[8] = p->rt_data.tchem.mass_fraction_H2II * rho;
+
+    const gr_float rho_e2 = species_densities[1] + 0.25 * species_densities[3] +
+                         0.5 * species_densities[4] - species_densities[6] + 0.5 * species_densities[8];
+    species_densities[5] = rho_e2;
+  #endif
 }
 
 /**


### PR DESCRIPTION
I added three extra species(HM, H2I, H2II) to let GEARRT now be able to run grackle chemistry mode 2

- allocate memory for three extra species
- define a macro RT_N_SPECIES for counting the number of species in each mode and using in species_densities[RT_N_SPECIES]
- add the initial condition for these species to be zero
- in do_thermochemistry function, add three extra species and also update the electron number density calculation